### PR TITLE
Save merged branches in reverse order

### DIFF
--- a/scarlet_extensions/testing/api.py
+++ b/scarlet_extensions/testing/api.py
@@ -87,7 +87,7 @@ def update_merged_branches(repo_path: str) -> None:
 
     commits = [c for c in repo.iter_commits(merges=True)]
     messages = [c.message.split("\n")[0] for c in commits]
-    branches = [(m.split("pmelchior/")[1]) for m in messages if "pmelchior" in m]
+    branches = [(m.split("pmelchior/")[1]) for m in messages if "pmelchior" in m][::-1]
     table = aws.get_table("scarlet_merged")
     with table.batch_writer() as batch:
         for idx, branch in enumerate(branches):


### PR DESCRIPTION
`git` returns the list of merged branches with the newest first.
AWS needs the sort order as a key, but that means re-writing
the order each time a new branch is merged. This commit reverses
the order of the list, making the oldest branch use key 0, so
that for future merged branches the keys will stay the same
and will no longer create duplicate entries.